### PR TITLE
Feature/argocd auto deploy

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -86,3 +86,20 @@ resource "null_resource" "list_load_balancers_on_destroy" {
     command = "bash ${path.module}/scripts/delete_lbs.sh"
   }
 }
+
+resource "null_resource" "update_kubeconfig" {
+  provisioner "local-exec" {
+    command = "aws eks update-kubeconfig --name ${module.eks.cluster_name} --role-arn ${module.eks.cluster_iam_role_arn}"
+  }
+
+  depends_on = [module.eks]
+}
+
+resource "null_resource" "cluster_configured" {
+  depends_on = [null_resource.update_kubeconfig]
+
+  # Use triggers to force recreation if the kubeconfig is updated
+  triggers = {
+    kubeconfig_updated = "${null_resource.update_kubeconfig.id}"
+  }
+}

--- a/commands.txt
+++ b/commands.txt
@@ -1,8 +1,21 @@
 commands:
-##Create aws-load-balancer-controller iam service account
+#Connect Cluster - Automatically configured by Terraform
+kubectl config get-contexts
+aws eks update-kubeconfig --name ekslab --role-arn arn:aws:iam::<ACCOUNT_ID>:role/<CLUSTER_ROLE_NAME>
+kubectl config get-contexts
+kubectl config use-context arn:aws:eks:<REGION>:<ACCOUNT_ID>:cluster/<cluster_name>
+
+#Expose ArgoCD port and login - Automatically run by Terraform
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+export ARGOCD_SERVER=`kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname'`
+export ARGO_PWD=`kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`
+argocd login $ARGOCD_SERVER --username admin --password $ARGO_PWD --insecure
+
+
+##Create aws-load-balancer-controller iam service account - Automatically created by Terraform
 kubectl apply -f deployment/aws-load-balancer-controller-sa.yaml
 
-## Instal aws-load-balancer-controller
+## Instal aws-load-balancer-controller - Automatically installed by Terraform
 helm install aws-load-balancer-controller eks/aws-load-balancer-controller --set clusterName=ekslab --set serviceAccount.create=false --set region=eu-west-1 --set vpcId=vpc-0ecb81b584011100b --set serviceAccount.name=aws-load-balancer-controller -n kube-system
 
 

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,9 @@
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
+data "aws_availability_zones" "available" {}
+
 data "aws_eks_cluster_auth" "auth" {
   name = module.eks.cluster_name
+  depends_on = [ module.eks ]
 }
-data "aws_availability_zones" "available" {}

--- a/deployment/aws-load-balancer-controller-sa.yaml
+++ b/deployment/aws-load-balancer-controller-sa.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/name: aws-load-balancer-controller
-  name: aws-load-balancer-controller
-  namespace: kube-system

--- a/iam.tf
+++ b/iam.tf
@@ -90,6 +90,7 @@ module "aws_lb_controller_iam_policy" {
 
 data "aws_iam_openid_connect_provider" "oidc" {
   url = module.eks.cluster_oidc_issuer_url
+  depends_on = [ module.eks ]
 }
 
 module "iam_eks_lb_controller_role" {

--- a/provider.tf
+++ b/provider.tf
@@ -6,7 +6,7 @@ provider "kubernetes" {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     exec {
-        api_version = "client.authentication.k8s.io/v1alpha1"
+        api_version = "client.authentication.k8s.io/v1beta1"
         args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
         command     = "aws"
      }

--- a/scripts/argo_login.sh
+++ b/scripts/argo_login.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+ARGOCD_SERVER=$(kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname')
+ARGO_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+
+# Check if ArgoCD server is up
+echo "Waiting for ArgoCD server to be ready..."
+for i in {1..30}; do
+  if curl -k -s --head --request GET https://$ARGOCD_SERVER | grep "200 OK" > /dev/null; then
+    echo "ArgoCD server is ready."
+    argocd login $ARGOCD_SERVER --username admin --password $ARGO_PWD --insecure
+    break
+  else
+    echo "ArgoCD server not ready yet, retrying in 10 seconds..."
+    sleep 10
+  fi
+done
+
+# Output the variables
+echo "ARGOCD_SERVER=$ARGOCD_SERVER"
+echo "ARGO_PWD=$ARGO_PWD"


### PR DESCRIPTION
This PR includes the following changes:

- Moved the update_kubeconfig resource to cluster.tf for better organization and removed unnecessary dependencies.
- Added a resource to declare the completion of cluster configuration.
- Included a command to specify if the configuration is already automated by Terraform.
- Added necessary dependencies to avoid potential failures.
- Automated the ArgoCD Helm installation process.
- Ensured the update_kubeconfig resource depends on the EKS module creation.
- Updated the Kubernetes authentication version for compatibility.
- Exported ArgoCD login commands to an external bash script and added a ping test to ensure the ArgoCD server is up and running.